### PR TITLE
added back dashboard and referenced applicationparts

### DIFF
--- a/Group-11-Orleans/API/API.csproj
+++ b/Group-11-Orleans/API/API.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.Orleans.Core" Version="3.1.7" />
     <PackageReference Include="Microsoft.Orleans.OrleansRuntime" Version="3.1.7" />
     <PackageReference Include="Microsoft.Orleans.Persistence.AzureStorage" Version="3.1.7" />
+    <PackageReference Include="OrleansDashboard" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Group-11-Orleans/API/Program.cs
+++ b/Group-11-Orleans/API/Program.cs
@@ -8,12 +8,14 @@ using Orleans;
 using Orleans.Hosting;
 using Orleans.Configuration;
 using System.Threading.Tasks;
+using Infrastructure.Interfaces;
+using OrleansBasics;
 
 namespace AspNetCoreCohosting
 {
     public class Program
     {
-        public static Task Main(string[] args) => 
+        public static Task Main(string[] args) =>
             Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
@@ -48,7 +50,12 @@ namespace AspNetCoreCohosting
                         opts.ClusterId = "wdm-group11-orleans-silocluster";
                         opts.ServiceId = "wdm-group11-orleans-api";
                     })
-                     .AddAzureTableGrainStorage(
+                .ConfigureApplicationParts(parts =>
+                {
+                    parts.AddApplicationPart(typeof(IOrderGrain).Assembly).WithReferences();
+                    parts.AddApplicationPart(typeof(OrderGrain).Assembly).WithReferences();
+                })
+                .AddAzureTableGrainStorage(
                     name: "orderStore",
                     configureOptions: options =>
                     {
@@ -56,7 +63,7 @@ namespace AspNetCoreCohosting
                         options.TableName = "orderStore";
                         options.ConnectionString = connectionString;
                     })
-               .AddAzureTableGrainStorage(
+                .AddAzureTableGrainStorage(
                     name: "stockStore",
                     configureOptions: options =>
                     {
@@ -72,7 +79,8 @@ namespace AspNetCoreCohosting
                         options.TableName = "userStore";
                         options.ConnectionString = connectionString;
                     })
-                    .Configure<EndpointOptions>(opts =>
+                .UseDashboard(opts => { })
+                .Configure<EndpointOptions>(opts =>
                     {
                         opts.AdvertisedIPAddress = IPAddress.Loopback;
                     });

--- a/Group-11-Orleans/Interfaces/Interfaces.csproj
+++ b/Group-11-Orleans/Interfaces/Interfaces.csproj
@@ -5,8 +5,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Core" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Orleans.CodeGenerator.MSBuild" Version="3.1.7">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Orleans.Core" Version="3.1.7" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Referencing applicationparts assemblies is required so that the grains and interfaces can be found quickly. I also updated the interfaces msbuild packages to be consistent with the grains. Dashboard is back at 8080